### PR TITLE
Enable newline via commandline

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,6 +4,7 @@ pub const DEFAULT_ENABLE_SPECIAL: bool = false;
 pub const DEFAULT_ENABLE_UPPER: bool = true;
 pub const DEFAULT_PASS_LEN: usize = 38;
 pub const DEFAULT_PRINT_HELP: bool = false;
+pub const DEFAULT_ENABLE_NEWLINE: bool = false;
 
 pub const SPECIAL_CHARS: [char; 14] = [
     '!', '#', '$', '%', '&', '*', ']', '[', '(', ')', '{', '}', '+', '-',

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,9 +1,9 @@
+pub const DEFAULT_ENABLE_DIGIT: bool = true;
+pub const DEFAULT_ENABLE_LOWER: bool = true;
+pub const DEFAULT_ENABLE_SPECIAL: bool = false;
+pub const DEFAULT_ENABLE_UPPER: bool = true;
 pub const DEFAULT_PASS_LEN: usize = 38;
 pub const DEFAULT_PRINT_HELP: bool = false;
-pub const DEFAULT_ENABLE_LOWER: bool = true;
-pub const DEFAULT_ENABLE_UPPER: bool = true;
-pub const DEFAULT_ENABLE_DIGIT: bool = true;
-pub const DEFAULT_ENABLE_SPECIAL: bool = false;
 
 pub const SPECIAL_CHARS: [char; 14] = [
     '!', '#', '$', '%', '&', '*', ']', '[', '(', ')', '{', '}', '+', '-',

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,10 @@ fn main() {
     }
 
     //emit password to user
-    println!("{}", pass);
+    match config.enable_newline {
+        true =>  println!("{}", pass),
+        false =>  print!("{}", pass),
+    }
 }
 
 // Print usage data
@@ -43,9 +46,9 @@ fn print_usage() {
     message += "By default, the password is 38 characters long.\n";
     message += "For a custom length, simply specify a numeric length as an argument.\n\n";
     message += "Options:\n";
+    message += "-n             Enable newline when printing password\n";
     message += "-nd            Disable numeric characters\n";
     message += "-nl            Disable lowercase characters\n";
-    message += "-nn            Disable newline when printing password\n";
     message += "-nu            Disable uppercase characters\n";
     message += "-s             Enable special characters in generations (!, @, #, $, etc)\n";
     message += "-h, --help     Print this help dialogue\n\n";

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,9 +43,10 @@ fn print_usage() {
     message += "By default, the password is 38 characters long.\n";
     message += "For a custom length, simply specify a numeric length as an argument.\n\n";
     message += "Options:\n";
-    message += "-nl            Disable lowercase characters\n";
-    message += "-nu            Disable uppercase characters\n";
     message += "-nd            Disable numeric characters\n";
+    message += "-nl            Disable lowercase characters\n";
+    message += "-nn            Disable newline when printing password\n";
+    message += "-nu            Disable uppercase characters\n";
     message += "-s             Enable special characters in generations (!, @, #, $, etc)\n";
     message += "-h, --help     Print this help dialogue\n\n";
 

--- a/src/parseargs.rs
+++ b/src/parseargs.rs
@@ -4,34 +4,34 @@ use std::str::FromStr;
 use crate::constants;
 
 pub struct ConfigArgs {
-    pub pass_length: usize,
-    pub print_help: bool,
     pub enable_digit: bool,
-    pub enable_upper: bool,
     pub enable_lower: bool,
     pub enable_special: bool,
+    pub enable_upper: bool,
+    pub pass_length: usize,
+    pub print_help: bool,
 }
 
 impl ConfigArgs {
     pub fn new() -> ConfigArgs {
         ConfigArgs {
+            enable_digit: constants::DEFAULT_ENABLE_DIGIT,
+            enable_lower: constants::DEFAULT_ENABLE_LOWER,
+            enable_special: constants::DEFAULT_ENABLE_SPECIAL,
+            enable_upper: constants::DEFAULT_ENABLE_UPPER,
             pass_length: constants::DEFAULT_PASS_LEN,
             print_help: constants::DEFAULT_PRINT_HELP,
-            enable_lower: constants::DEFAULT_ENABLE_LOWER,
-            enable_upper: constants::DEFAULT_ENABLE_UPPER,
-            enable_digit: constants::DEFAULT_ENABLE_DIGIT,
-            enable_special: constants::DEFAULT_ENABLE_SPECIAL,
         }
     }
 
     pub fn read_args(&mut self) {
         for (count, arg) in env::args().enumerate() {
             match arg.as_ref() {
+                "-h" | "--help" => self.print_help = true,
+                "-nd" => self.enable_digit = false,
                 "-nl" => self.enable_lower = false,
                 "-nu" => self.enable_upper = false,
-                "-nd" => self.enable_digit = false,
                 "-s" => self.enable_special = true,
-                "-h" | "--help" => self.print_help = true,
                 _ => {
                     if count > 0 {
                         self.validate_possible_numeric(arg.as_ref())

--- a/src/parseargs.rs
+++ b/src/parseargs.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use crate::constants;
 
 pub struct ConfigArgs {
+    pub enable_newline: bool,
     pub enable_digit: bool,
     pub enable_lower: bool,
     pub enable_special: bool,
@@ -15,6 +16,7 @@ pub struct ConfigArgs {
 impl ConfigArgs {
     pub fn new() -> ConfigArgs {
         ConfigArgs {
+            enable_newline: constants::DEFAULT_ENABLE_NEWLINE,
             enable_digit: constants::DEFAULT_ENABLE_DIGIT,
             enable_lower: constants::DEFAULT_ENABLE_LOWER,
             enable_special: constants::DEFAULT_ENABLE_SPECIAL,
@@ -28,6 +30,7 @@ impl ConfigArgs {
         for (count, arg) in env::args().enumerate() {
             match arg.as_ref() {
                 "-h" | "--help" => self.print_help = true,
+                "-n" => self.enable_newline = true,
                 "-nd" => self.enable_digit = false,
                 "-nl" => self.enable_lower = false,
                 "-nu" => self.enable_upper = false,


### PR DESCRIPTION
Currently, password generation also prints a newline, so something like the following cannot be copy-pasted directly into an input field:

```bash
./pass-rs | xclip -selection clipboard
```
Passing `-n` as a commandline argument enables newline if necessary.